### PR TITLE
Add support for stopping generation during a stream.

### DIFF
--- a/include/ollama.hpp
+++ b/include/ollama.hpp
@@ -463,6 +463,7 @@ class Ollama
         };
 
         if (auto res = this->cli->Post("/api/generate", request_string, "application/json", stream_callback)) { return true; }
+        else if (res.error()==httplib::Error::Canceled) { /* Request cancelled by user. */ return true; }        
         else { if (ollama::use_exceptions) throw ollama::exception( "No response from server returned at URL "+this->server_url+" Error: "+httplib::to_string( res.error() ) ); } 
 
         return false;
@@ -539,6 +540,7 @@ class Ollama
         };
 
         if (auto res = this->cli->Post("/api/chat", request_string, "application/json", stream_callback)) { return true; }
+        else if (res.error()==httplib::Error::Canceled) { /* Request cancelled by user. */ return true; }
         else { if (ollama::use_exceptions) throw ollama::exception( "No response from server returned at URL"+this->server_url+" Error: "+httplib::to_string( res.error() ) ); }
 
         return false;

--- a/singleheader/ollama.hpp
+++ b/singleheader/ollama.hpp
@@ -34796,7 +34796,7 @@ public:
 
 /*  MIT License
 
-    Copyright (c) 2024 James Montgomery (jmont)
+    Copyright (c) 2025 James Montgomery (jmont)
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -35209,14 +35209,14 @@ class Ollama
         return response;        
     }
 
-    bool generate(const std::string& model,const std::string& prompt, ollama::response& context, std::function<void(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
+    bool generate(const std::string& model,const std::string& prompt, ollama::response& context, std::function<bool(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
     {
         ollama::request request(model, prompt, options, true, images);
         if ( context.as_json().contains("context") ) request["context"] = context.as_json()["context"];
         return generate(request, on_receive_token);
     }
 
-    bool generate(const std::string& model,const std::string& prompt, std::function<void(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
+    bool generate(const std::string& model,const std::string& prompt, std::function<bool(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
     {
         ollama::request request(model, prompt, options, true, images);
         return generate(request, on_receive_token);
@@ -35224,7 +35224,7 @@ class Ollama
 
 
     // Generate a streaming reply where a user-defined callback function is invoked when each token is received.
-    bool generate(ollama::request& request, std::function<void(const ollama::response&)> on_receive_token)
+    bool generate(ollama::request& request, std::function<bool(const ollama::response&)> on_receive_token)
     {
         request["stream"] = true;
 
@@ -35236,6 +35236,8 @@ class Ollama
         auto stream_callback = [on_receive_token, partial_responses](const char *data, size_t data_length)->bool{
             
             std::string message(data, data_length);
+            bool continue_stream = true;
+
             if (ollama::log_replies) std::cout << message << std::endl;
             try 
             {   
@@ -35243,15 +35245,16 @@ class Ollama
                 std::string total_response = std::accumulate(partial_responses->begin(), partial_responses->end(), std::string(""));                
                 ollama::response response(total_response);
                 partial_responses->clear();  
-                on_receive_token(response); 
+                continue_stream = on_receive_token(response); 
             }
             catch (const ollama::invalid_json_exception& e) { /* Partial response was received. Will do nothing and attempt to concatenate with the next response. */ }
             
-            return true;
+            return continue_stream;
         };
 
         if (auto res = this->cli->Post("/api/generate", request_string, "application/json", stream_callback)) { return true; }
-        else { if (ollama::use_exceptions) throw ollama::exception( "No response from server returned at URL"+this->server_url+" Error: "+httplib::to_string( res.error() ) ); } 
+        else if (res.error()==httplib::Error::Canceled) { /* Request cancelled by user. */ return true; }        
+        else { if (ollama::use_exceptions) throw ollama::exception( "No response from server returned at URL "+this->server_url+" Error: "+httplib::to_string( res.error() ) ); } 
 
         return false;
     }
@@ -35288,14 +35291,14 @@ class Ollama
         return response;
     }
 
-    bool chat(const std::string& model, const ollama::messages& messages, std::function<void(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::string& format="json", const std::string& keep_alive_duration="5m")
+    bool chat(const std::string& model, const ollama::messages& messages, std::function<bool(const ollama::response&)> on_receive_token, const json& options=nullptr, const std::string& format="json", const std::string& keep_alive_duration="5m")
     {
         ollama::request request(model, messages, options, true, format, keep_alive_duration);
         return chat(request, on_receive_token);
     }
 
 
-    bool chat(ollama::request& request, std::function<void(const ollama::response&)> on_receive_token)
+    bool chat(ollama::request& request, std::function<bool(const ollama::response&)> on_receive_token)
     {
         ollama::response response;        
         request["stream"] = true;
@@ -35308,6 +35311,8 @@ class Ollama
         auto stream_callback = [on_receive_token, partial_responses](const char *data, size_t data_length)->bool{
             
             std::string message(data, data_length);
+            bool continue_stream = true;
+
             if (ollama::log_replies) std::cout << message << std::endl;
             try 
             {   
@@ -35317,14 +35322,15 @@ class Ollama
                 partial_responses->clear();  
 
                 if ( response.has_error() ) { if (ollama::use_exceptions) throw ollama::exception("Ollama response returned error: "+response.get_error() ); }
-                on_receive_token(response);
+                continue_stream = on_receive_token(response);
             }
             catch (const ollama::invalid_json_exception& e) { /* Partial response was received. Will do nothing and attempt to concatenate with the next response. */ }
 
-            return true;
+            return continue_stream;
         };
 
         if (auto res = this->cli->Post("/api/chat", request_string, "application/json", stream_callback)) { return true; }
+        else if (res.error()==httplib::Error::Canceled) { /* Request cancelled by user. */ return true; }
         else { if (ollama::use_exceptions) throw ollama::exception( "No response from server returned at URL"+this->server_url+" Error: "+httplib::to_string( res.error() ) ); }
 
         return false;
@@ -35662,7 +35668,7 @@ class Ollama
     private:
 
 /*
-    bool send_request(const ollama::request& request, std::function<void(const ollama::response&)> on_receive_response=nullptr)
+    bool send_request(const ollama::request& request, std::function<bool(const ollama::response&)> on_receive_response=nullptr)
     {
 
         return true;
@@ -35700,17 +35706,17 @@ namespace ollama
         return ollama.generate(request);
     }
 
-    inline bool generate(const std::string& model,const std::string& prompt, std::function<void(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
+    inline bool generate(const std::string& model,const std::string& prompt, std::function<bool(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
     {
         return ollama.generate(model, prompt, on_receive_response, options, images);
     }
 
-    inline bool generate(const std::string& model,const std::string& prompt, ollama::response& context, std::function<void(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
+    inline bool generate(const std::string& model,const std::string& prompt, ollama::response& context, std::function<bool(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::vector<std::string>& images=std::vector<std::string>())
     {
         return ollama.generate(model, prompt, context, on_receive_response, options, images);
     }
 
-    inline bool generate(ollama::request& request, std::function<void(const ollama::response&)> on_receive_response)
+    inline bool generate(ollama::request& request, std::function<bool(const ollama::response&)> on_receive_response)
     {
         return ollama.generate(request, on_receive_response);
     }
@@ -35725,12 +35731,12 @@ namespace ollama
         return ollama.chat(request);
     }
 
-    inline bool chat(const std::string& model, const ollama::messages& messages, std::function<void(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::string& format="json", const std::string& keep_alive_duration="5m")
+    inline bool chat(const std::string& model, const ollama::messages& messages, std::function<bool(const ollama::response&)> on_receive_response, const json& options=nullptr, const std::string& format="json", const std::string& keep_alive_duration="5m")
     {
         return ollama.chat(model, messages, on_receive_response, options, format, keep_alive_duration);
     }
 
-    inline bool chat(ollama::request& request, std::function<void(const ollama::response&)> on_receive_response)
+    inline bool chat(ollama::request& request, std::function<bool(const ollama::response&)> on_receive_response)
     {
         return ollama.chat(request, on_receive_response);
     }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -131,16 +131,17 @@ TEST_SUITE("Ollama Tests") {
     std::string streamed_response;
 
 
-    void on_receive_response(const ollama::response& response)
+    bool on_receive_response(const ollama::response& response)
     {   
         streamed_response+=response.as_simple_string();
-
         if (response.as_json()["done"]==true) done=true;
+
+        return true;
     }
 
     TEST_CASE("Streaming Generation") {
 
-        std::function<void(const ollama::response&)> response_callback = on_receive_response;  
+        std::function<bool(const ollama::response&)> response_callback = on_receive_response;  
         ollama::generate(test_model, "Why is the sky blue?", response_callback, options);
 
         std::string expected_response = "What a great question!\n\nThe sky appears blue because of a phenomenon called Rayleigh scattering,";
@@ -152,7 +153,7 @@ TEST_SUITE("Ollama Tests") {
 
         ollama::response context = ollama::generate(test_model, "Why is the sky blue?", options);
 
-        std::function<void(const ollama::response&)> response_callback = on_receive_response;  
+        std::function<bool(const ollama::response&)> response_callback = on_receive_response;  
         ollama::generate(test_model, "Tell me more about this.", context, response_callback, options);
 
         CHECK( streamed_response!="" );
@@ -204,7 +205,7 @@ TEST_SUITE("Ollama Tests") {
         streamed_response="";
         done.store(false);
 
-        std::function<void(const ollama::response&)> response_callback = on_receive_response;  
+        std::function<bool(const ollama::response&)> response_callback = on_receive_response;  
         
         ollama::message message("user", "Why is the sky blue?");       
         


### PR DESCRIPTION
Adds support to gracefully stop an active stream using either the `generate` or `chat` endpoints. The bound response function has been changed to return a bool which determines whether or not to continue streaming for this response.

When used asynchronously, a simple atomic variable can be used to return false from the calling thread in order to stop a stream launched in another thread. See the cases added in `test` for an example of doing so.