### PR TITLE
Add a method for unloading a model from Ollama's memory

### DIFF
--- a/include/ollama.hpp
+++ b/include/ollama.hpp
@@ -628,6 +628,30 @@ class Ollama
         return false;                
     }
 
+    bool unload_model(const std::string& model)
+    {
+        json request;
+        request["model"] = model;
+        request["keep_alive"] = 0;
+        std::string request_string = request.dump();
+        if (ollama::log_requests) std::cout << request_string << std::endl;
+
+        // Send a request with the model name and keep_alive set to zero to instruct ollama to unload the model from memory.
+        if (auto res = this->cli->Post("/api/generate", request_string, "application/json"))
+        {
+            if (ollama::log_replies) std::cout << res->body << std::endl;
+            json response = json::parse(res->body);
+            return response["done"];        
+        }
+        else
+        { 
+            if (ollama::use_exceptions) throw ollama::exception("No response returned from server when unloading model: "+httplib::to_string( res.error() ) ); 
+        }
+
+        // If we didn't get a response from the server indicating the model was created, return false.        
+        return false;                
+    }
+
     bool is_running()
     {
         auto res = cli->Get("/");

--- a/include/ollama.hpp
+++ b/include/ollama.hpp
@@ -1039,6 +1039,11 @@ namespace ollama
         return ollama.load_model(model);
     }
 
+    inline bool unload_model(const std::string& model)
+    {
+        return ollama.load_model(model);
+    }
+
     inline std::string get_version()
     {
         return ollama.get_version();

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -52,9 +52,13 @@ TEST_SUITE("Ollama Tests") {
         CHECK(true);
     }
 
-    TEST_CASE("Load Model") {
+    TEST_CASE("Load and Unload Models") {
 
+        // Load a model into memory
         CHECK( ollama::load_model(test_model) );
+
+        // Remove a model from memory
+        CHECK( ollama::unload_model(test_model) );
     }
 
     TEST_CASE("Pull, Copy, and Delete Models") {


### PR DESCRIPTION
Hi, this PR add an additional public method in ollama class to facilitate memory management in the Ollama server. By default, models are removed from memory after 5 minutes of inactivity, but an application utilizing a number of different models might benefit from an unload method.

I have already implemented this method in my own version of your library I use for the [`llms`](https://github.com/pr0m1th3as/octave-llms) Octave Package and it works great. However, I have not tested this with the CI of your repository, despite adding the method in the test suite. 

I did not commit a changeset in the README file because I am not sure whether you prefer to group this method with the load method or have it in a separate sub-section. 