### PR TITLE
Added case Error::SSLPeerCouldBeClosed_ to the switch/case of the to_string function.

### DIFF
--- a/include/httplib.h
+++ b/include/httplib.h
@@ -2132,6 +2132,7 @@ inline std::string to_string(const Error error) {
   case Error::ConnectionTimeout: return "Connection timed out";
   case Error::ProxyConnection: return "Proxy connection failed";
   case Error::Unknown: return "Unknown";
+  case Error::SSLPeerCouldBeClosed_: return "This error is for internal use only (SSLPeerCouldBeClosed_)";
   default: break;
   }
 

--- a/singleheader/ollama.hpp
+++ b/singleheader/ollama.hpp
@@ -26923,6 +26923,7 @@ inline std::string to_string(const Error error) {
   case Error::ConnectionTimeout: return "Connection timed out";
   case Error::ProxyConnection: return "Proxy connection failed";
   case Error::Unknown: return "Unknown";
+  case Error::SSLPeerCouldBeClosed_: return "This error is for internal use only (SSLPeerCouldBeClosed_)";
   default: break;
   }
 
@@ -34990,8 +34991,8 @@ namespace hash
 */
 
 /*
-    A lightweight, header-only implementation of sha256 hashing. This is used for blob verifcation when uploading
-    GGUF files to Ollama.
+    sha256.hpp is a lightweight, header-only implementation of sha256 hashing. 
+    This is used for blob verifcation when uploading GGUF files to Ollama.
     No license is necessary for this code.
 */
 


### PR DESCRIPTION
Many libraries and software projects use the `-Werror=switch-enum`. This leads to an error if the switch/case on an enum is not exhaustive. This was the case in the to_string function as it did not take care of the Error::SSLPeerCouldBeClosed_ case.

Since the SSLPeerCouldBeClosed_ is for internal use only, I have clarified this in the resulting string: `This error is for internal use only (SSLPeerCouldBeClosed_)`